### PR TITLE
Fixes for handling .gitignore edge cases in GitIgnorePattern.

### DIFF
--- a/pathspec/tests/test_gitignore.py
+++ b/pathspec/tests/test_gitignore.py
@@ -22,21 +22,60 @@ class GitIgnoreTest(unittest.TestCase):
 		self.assertIsNone(spec.include)
 		self.assertIsNone(spec.regex)
 
+	def test_01_absolute_root(self):
+		"""
+		Tests a single root absolute path pattern.
+
+		This should NOT match any file (according to git check-ignore (v2.4.1)).
+		"""
+		spec = GitIgnorePattern('/')
+		self.assertIsNone(spec.include)
+		self.assertIsNone(spec.regex)
+
 	def test_01_absolute(self):
 		"""
 		Tests an absolute path pattern.
+
+		This should match:
+		an/absolute/file/path
+		an/absolute/file/path/foo
+
+		This should NOT match:
+		foo/an/absolute/file/path
 		"""
 		spec = GitIgnorePattern('/an/absolute/file/path')
 		self.assertTrue(spec.include)
-		self.assertEquals(spec.regex.pattern, '^an/absolute/file/path$')
+		self.assertEquals(spec.regex.pattern, '^an/absolute/file/path(?:/.*)?$')
 
 	def test_01_relative(self):
 		"""
 		Tests a relative path pattern.
+
+		This should match:
+		spam
+		spam/
+		foo/spam
+		spam/foo
+		foo/spam/bar
 		"""
 		spec = GitIgnorePattern('spam')
 		self.assertTrue(spec.include)
-		self.assertEquals(spec.regex.pattern, '^(?:.+/)?spam$')
+		self.assertEquals(spec.regex.pattern, '^(?:.+/)?spam(?:/.*)?$')
+
+	def test_01_relative_nested(self):
+		"""
+		Tests a relative nested path pattern.
+
+		This should match:
+		foo/spam
+		foo/spam/bar
+
+		This should **not** match (according to git check-ignore (v2.4.1)):
+		bar/foo/spam
+		"""
+		spec = GitIgnorePattern('foo/spam')
+		self.assertTrue(spec.include)
+		self.assertEquals(spec.regex.pattern, '^foo/spam(?:/.*)?$')
 
 	def test_02_comment(self):
 		"""
@@ -49,6 +88,9 @@ class GitIgnoreTest(unittest.TestCase):
 	def test_02_ignore(self):
 		"""
 		Tests an exclude pattern.
+
+		This should NOT match (according to git check-ignore (v2.4.1)):
+		temp/foo
 		"""
 		spec = GitIgnorePattern('!temp')
 		self.assertIsNotNone(spec.include)
@@ -59,18 +101,32 @@ class GitIgnoreTest(unittest.TestCase):
 		"""
 		Tests a directory name with a double-asterisk child
 		directory.
+
+		This should match:
+		spam/bar
+
+		This should **not** match (according to git check-ignore (v2.4.1)):
+		foo/spam/bar
 		"""
 		spec = GitIgnorePattern('spam/**')
 		self.assertTrue(spec.include)
-		self.assertEquals(spec.regex.pattern, '^(?:.+/)?spam/.*$')
+		self.assertEquals(spec.regex.pattern, '^spam/.*$')
 
 	def test_03_inner_double_asterisk(self):
 		"""
 		Tests a path with an inner double-asterisk directory.
+
+		This should match:
+		left/bar/right
+		left/foo/bar/right
+		left/bar/right/foo
+
+		This should **not** match (according to git check-ignore (v2.4.1)):
+		foo/left/bar/right
 		"""
 		spec = GitIgnorePattern('left/**/right')
 		self.assertTrue(spec.include)
-		self.assertEquals(spec.regex.pattern, '^(?:.+/)?left(?:/.+)?/right$')
+		self.assertEquals(spec.regex.pattern, '^left(?:/.+)?/right(?:/.*)?$')
 
 	def test_03_only_double_asterisk(self):
 		"""
@@ -83,38 +139,70 @@ class GitIgnoreTest(unittest.TestCase):
 	def test_03_parent_double_asterisk(self):
 		"""
 		Tests a file name with a double-asterisk parent directory.
+
+		This should match:
+		foo/spam
+		foo/spam/bar
 		"""
 		spec = GitIgnorePattern('**/spam')
 		self.assertTrue(spec.include)
-		self.assertEquals(spec.regex.pattern, '^(?:.+/)?spam$')
+		self.assertEquals(spec.regex.pattern, '^(?:.+/)?spam(?:/.*)?$')
 
 	def test_04_infix_wildcard(self):
 		"""
 		Tests a pattern with an infix wildcard.
+
+		This should match:
+		foo--bar
+		foo-hello-bar
+		a/foo-hello-bar
+		foo-hello-bar/b
+		a/foo-hello-bar/b
 		"""
 		spec = GitIgnorePattern('foo-*-bar')
 		self.assertTrue(spec.include)
-		self.assertEquals(spec.regex.pattern, '^(?:.+/)?foo\\-[^/]*\\-bar$')
+		self.assertEquals(spec.regex.pattern, '^(?:.+/)?foo\\-[^/]*\\-bar(?:/.*)?$')
 
 	def test_04_postfix_wildcard(self):
 		"""
 		Tests a pattern with a postfix wildcard.
+
+		This should match:
+		~temp-
+		~temp-foo
+		~temp-foo/bar
+		foo/~temp-bar
+		foo/~temp-bar/baz
 		"""
 		spec = GitIgnorePattern('~temp-*')
 		self.assertTrue(spec.include)
-		self.assertEquals(spec.regex.pattern, '^(?:.+/)?\\~temp\\-[^/]*$')
+		self.assertEquals(spec.regex.pattern, '^(?:.+/)?\\~temp\\-[^/]*(?:/.*)?$')
 
 	def test_04_prefix_wildcard(self):
 		"""
 		Tests a pattern with a prefix wildcard.
+
+		This should match:
+		bar.py
+		bar.py/
+		foo/bar.py
+		foo/bar.py/baz
 		"""
 		spec = GitIgnorePattern('*.py')
 		self.assertTrue(spec.include)
-		self.assertEquals(spec.regex.pattern, '^(?:.+/)?[^/]*\\.py$')
+		self.assertEquals(spec.regex.pattern, '^(?:.+/)?[^/]*\\.py(?:/.*)?$')
 
 	def test_05_directory(self):
 		"""
 		Tests a directory pattern.
+
+		This should match:
+		dir/
+		foo/dir/
+		foo/dir/bar
+
+		This should **not** match:
+		dir
 		"""
 		spec = GitIgnorePattern('dir/')
 		self.assertTrue(spec.include)


### PR DESCRIPTION
The git client (tested with v2.4.1) exhibits differing behavior than pathspec's GitIgnorePattern, including:

- `/` does NOT match all paths the repo
- `/abs/path` matches: `abs/path/foo`
- `spam` matches: `spam/`, `spam/foo`
- `spam/two` does NOT match: `foo/spam/two`
- `spam/**` does NOT match: `foo/spam/bar`
- `left/**/right` does NOT match: `foo/left/bar/right`
- `**/spam` does match: `foo/spam/`, `foo/spam/bar`
- `foo-*-bar` does match: `foo-hello-bar/baz`
- `~temp-*` does match: `~temp-foo/bar`
- `*.py` does match: `bar.py/baz`

Tests for each of these cases have been added. While some of these edge cases may be bugs in git, until they are fixed, I believe that pathspec should handle .gitignore files as close as possible to how git handles them. I marked these edge cases with `EDGE CASE` comments so that they can be easily removed in the future.

More complex behavior, such as an include pattern followed by an exclude pattern were not tested since they would involve integration tests.

Thank you so much for creating this library!