### PR TITLE
Notify of API change in 0.3.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Change History
 
 - Improved documentation.
 - Issue #6: Fixed matching Windows paths.
+- API change: `spec.match_tree` and `spec.match_files` now return iterators instead of sets
 
 
 0.3.1 (2014-09-17)


### PR DESCRIPTION
In 0.3.2, the fix to Issue #6 in commit 45829da837d7447725e2a4b08d756b53cffd2fb8 also changed the API of the spec object to return iterators instead of sets (see https://github.com/cpburnz/python-path-specification/issues/6#issuecomment-62147166). This can break existing code using the library, so should be clearly mentioned