### PR TITLE
Add equality method to PathSpec

### DIFF
--- a/pathspec/pathspec.py
+++ b/pathspec/pathspec.py
@@ -5,6 +5,7 @@ of files.
 """
 
 import collections
+from itertools import izip_longest
 
 from . import util
 from .compat import string_types, viewkeys
@@ -36,7 +37,7 @@ class PathSpec(object):
 		Tests equality of this ``PathSpec`` with ``other`` based on the
 		regexs contained in their ``patterns``.
 		"""
-		paired_patterns = zip(self.patterns, other.patterns)
+		paired_patterns = izip_longest(self.patterns, other.patterns)
 		return all(a.regex == b.regex for a, b in paired_patterns)
 
 	def __len__(self):

--- a/pathspec/pathspec.py
+++ b/pathspec/pathspec.py
@@ -30,6 +30,14 @@ class PathSpec(object):
 		"""
 
 		self.patterns = patterns if isinstance(patterns, collections.Container) else list(patterns)
+		
+	def __eq__(self, other):
+		"""
+		Tests equality of this ``PathSpec`` with ``other`` based on the
+		regexs contained in their ``patterns``.
+		"""
+		paired_patterns = zip(self.patterns, other.patterns)
+		return all(a.regex == b.regex for a, b in paired_patterns)
 
 	def __len__(self):
 		"""


### PR DESCRIPTION
This adds the `__eq__` method so you can compare two PathSpec instances for equality.

Personally I want this to see if a PathSpec instance has been instantiated with a default gitignore but I'm sure it would be useful to others too :)