### PR TITLE
Include LICENSE file in dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.rst
+include LICENSE


### PR DESCRIPTION
I am packaging pathspec for Fedora and CentOS, but there's a licensing
issue because the LICENSE file is not shipped in the source package.

This commit should fix that.