### PR TITLE
Link to Ruby gem port of pathspec

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,3 +135,11 @@ Installation
 
 .. _`setuptools`: https://pypi.python.org/pypi/setuptools
 .. _`PyPI`: http://pypi.python.org/pypi/pathspec
+
+Other Languages
+---------------
+
+*pathspec* is also available as a `Ruby gem`_.
+
+.. _`Ruby gem`: https://github.com/highb/pathspec-ruby
+


### PR DESCRIPTION
Hi, I made a Ruby gem based on your library a while back. This PR adds a link to it in the README. If you have a moment, check out my shout out to this library in my repo's [README](https://github.com/highb/pathspec-ruby/blob/master/README.md). Thanks!