### PR TITLE
Publish sdist and bdist wheel

### DIFF
--- a/pypi-upload.sh
+++ b/pypi-upload.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python setup.py sdist upload
+python setup.py sdist bdist_wheel upload

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,1 +1,2 @@
-[egg_info]
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
The benefits of wheels are well documented. See: https://pythonwheels.com/
This package is pure Python and publishing it as both source and as a wheel is simple.