### PR TITLE
Accept pathlib.Path as arguments

### DIFF
--- a/pathspec/__init__.py
+++ b/pathspec/__init__.py
@@ -47,6 +47,7 @@ __credits__ = [
 	"jdufresne <https://github.com/jdufresne>",
 	"groodt <https://github.com/groodt>",
 	"ftrofin <https://github.com/ftrofin>",
+	"pykong <https://github.com/pykong>"
 ]
 __email__ = "cpburnz@gmail.com"
 __license__ = "MPL 2.0"

--- a/pathspec/pathspec.py
+++ b/pathspec/pathspec.py
@@ -78,7 +78,7 @@ class PathSpec(object):
 		"""
 		Matches the file to this path-spec.
 
-		*file* (:class:`str` or :class: `Path`) is the file path to be
+		*file* (:class:`str`; or :class: `Path`) is the file path to be
 		matched against :attr:`self.patterns <PathSpec.patterns>`.
 
 		*separators* (:class:`~collections.abc.Collection` of :class:`str`)
@@ -95,7 +95,7 @@ class PathSpec(object):
 		Matches the files to this path-spec.
 
 		*files* (:class:`~collections.abc.Iterable` of
-		(:class:`str` or :class: `Path`)) contains the file paths to be
+		(:class:`str`; or :class: `Path`)) contains the file paths to be
 		matched against :attr:`self.patterns <PathSpec.patterns>`.
 
 		*separators* (:class:`~collections.abc.Collection` of :class:`str`;
@@ -119,7 +119,7 @@ class PathSpec(object):
 		Walks the specified root path for all files and matches them to this
 		path-spec.
 
-		*root* (:class:`str` or :class: `Path`) is the root directory to
+		*root* (:class:`str`; or :class: `Path`) is the root directory to
 		search for files.
 
 		*on_error* (:class:`~collections.abc.Callable` or :data:`None`)

--- a/pathspec/pathspec.py
+++ b/pathspec/pathspec.py
@@ -133,7 +133,6 @@ class PathSpec(object):
 		Returns the matched files (:class:`~collections.abc.Iterable` of
 		:class:`str`).
 		"""
-		root = str(root)  # stringify pathlib.Path
 		files = util.iter_tree_files(root, on_error=on_error, follow_links=follow_links)
 		return self.match_files(files)
 

--- a/pathspec/pathspec.py
+++ b/pathspec/pathspec.py
@@ -78,8 +78,8 @@ class PathSpec(object):
 		"""
 		Matches the file to this path-spec.
 
-		*file* (:class:`str`) is the file path to be matched against
-		:attr:`self.patterns <PathSpec.patterns>`.
+		*file* (:class:`str` or :class: `Path`) is the file path to be
+		matched against :attr:`self.patterns <PathSpec.patterns>`.
 
 		*separators* (:class:`~collections.abc.Collection` of :class:`str`)
 		optionally contains the path separators to normalize. See
@@ -94,9 +94,9 @@ class PathSpec(object):
 		"""
 		Matches the files to this path-spec.
 
-		*files* (:class:`~collections.abc.Iterable` of :class:`str`) contains
-		the file paths to be matched against :attr:`self.patterns
-		<PathSpec.patterns>`.
+		*files* (:class:`~collections.abc.Iterable` of
+		(:class:`str` or :class: `Path`)) contains the file paths to be
+		matched against :attr:`self.patterns <PathSpec.patterns>`.
 
 		*separators* (:class:`~collections.abc.Collection` of :class:`str`;
 		or :data:`None`) optionally contains the path separators to
@@ -119,7 +119,8 @@ class PathSpec(object):
 		Walks the specified root path for all files and matches them to this
 		path-spec.
 
-		*root* (:class:`str`) is the root directory to search for files.
+		*root* (:class:`str` or :class: `Path`) is the root directory to
+		search for files.
 
 		*on_error* (:class:`~collections.abc.Callable` or :data:`None`)
 		optionally is the error handler for file-system exceptions. See
@@ -132,6 +133,7 @@ class PathSpec(object):
 		Returns the matched files (:class:`~collections.abc.Iterable` of
 		:class:`str`).
 		"""
+		root = str(root)  # stringify pathlib.Path
 		files = util.iter_tree_files(root, on_error=on_error, follow_links=follow_links)
 		return self.match_files(files)
 

--- a/pathspec/tests/test_util.py
+++ b/pathspec/tests/test_util.py
@@ -375,6 +375,6 @@ class IterTreeTest(unittest.TestCase):
 		Tests passing pathlib.Path as argument.
 		"""
 		from pathlib import Path
-		first_spec = normalize_file([Path('a.txt')])
-		second_spec = normalize_file(['a.txt'])
+		first_spec = normalize_file(Path('a.txt'))
+		second_spec = normalize_file('a.txt')
 		self.assertEqual(first_spec, second_spec)

--- a/pathspec/tests/test_util.py
+++ b/pathspec/tests/test_util.py
@@ -7,6 +7,7 @@ import errno
 import os
 import os.path
 import shutil
+import sys
 import tempfile
 import unittest
 
@@ -368,6 +369,7 @@ class IterTreeTest(unittest.TestCase):
 			'Empty',
 		])))
 
+	@unittest.skipIf(sys.version_info < (3, 4), "pathlib entered stdlib in Python 3.4")
 	def test_4_normalizing_pathlib_paths(self):
 		"""
 		Tests passing pathlib.Path as argument.
@@ -375,4 +377,4 @@ class IterTreeTest(unittest.TestCase):
 		from pathlib import Path
 		first_spec = normalize_file([Path('a.txt')])
 		second_spec = normalize_file(['a.txt'])
-		self.assertNotEqual(first_spec, second_spec)
+		self.assertEqual(first_spec, second_spec)

--- a/pathspec/tests/test_util.py
+++ b/pathspec/tests/test_util.py
@@ -10,7 +10,7 @@ import shutil
 import tempfile
 import unittest
 
-from pathspec.util import iter_tree_entries, iter_tree_files, RecursionError
+from pathspec.util import iter_tree_entries, iter_tree_files, RecursionError, normalize_file
 
 
 class IterTreeTest(unittest.TestCase):
@@ -367,3 +367,12 @@ class IterTreeTest(unittest.TestCase):
 			'Dir/Inner/f',
 			'Empty',
 		])))
+
+	def test_4_normalizing_pathlib_paths(self):
+		"""
+		Tests passing pathlib.Path as argument.
+		"""
+		from pathlib import Path
+		first_spec = normalize_file([Path('a.txt')])
+		second_spec = normalize_file(['a.txt'])
+		self.assertNotEqual(first_spec, second_spec)

--- a/pathspec/tests/test_util.py
+++ b/pathspec/tests/test_util.py
@@ -370,7 +370,7 @@ class IterTreeTest(unittest.TestCase):
 		])))
 
 	@unittest.skipIf(sys.version_info < (3, 4), "pathlib entered stdlib in Python 3.4")
-	def test_4_normalizing_pathlib_paths(self):
+	def test_4_normalizing_pathlib_path(self):
 		"""
 		Tests passing pathlib.Path as argument.
 		"""

--- a/pathspec/util.py
+++ b/pathspec/util.py
@@ -262,7 +262,7 @@ def normalize_file(file, separators=None):
 	"""
 	Normalizes the file path to use the POSIX path separator (i.e., ``'/'``).
 
-	*file* (:class:`str` or :class: `Path`) is the file path.
+	*file* (:class:`str`; or :class: `Path`) is the file path.
 
 	*separators* (:class:`~collections.abc.Collection` of :class:`str`; or
 	:data:`None`) optionally contains the path separators to normalize.
@@ -276,7 +276,7 @@ def normalize_file(file, separators=None):
 	# Normalize path separators.
 	if separators is None:
 		separators = NORMALIZE_PATH_SEPS
-	norm_file = str(file)
+	norm_file = str(file)  # stringify pathlib.Path
 	for sep in separators:
 		norm_file = norm_file.replace(sep, posixpath.sep)
 
@@ -290,8 +290,8 @@ def normalize_files(files, separators=None):
 	"""
 	Normalizes the file paths to use the POSIX path separator.
 
-	*files* (:class:`~collections.abc.Iterable` of :class:`str`) contains
-	the file paths to be normalized.
+	*files* (:class:`~collections.abc.Iterable` of :class:`str`;
+	or :class: `Path`) contains the file paths to be normalized.
 
 	*separators* (:class:`~collections.abc.Collection` of :class:`str`; or
 	:data:`None`) optionally contains the path separators to normalize.

--- a/pathspec/util.py
+++ b/pathspec/util.py
@@ -262,7 +262,7 @@ def normalize_file(file, separators=None):
 	"""
 	Normalizes the file path to use the POSIX path separator (i.e., ``'/'``).
 
-	*file* (:class:`str`) is the file path.
+	*file* (:class:`str` or :class: `Path`) is the file path.
 
 	*separators* (:class:`~collections.abc.Collection` of :class:`str`; or
 	:data:`None`) optionally contains the path separators to normalize.
@@ -276,7 +276,7 @@ def normalize_file(file, separators=None):
 	# Normalize path separators.
 	if separators is None:
 		separators = NORMALIZE_PATH_SEPS
-	norm_file = file
+	norm_file = str(file)
 	for sep in separators:
 		norm_file = norm_file.replace(sep, posixpath.sep)
 


### PR DESCRIPTION
This **PR** modernizes `pathspec` to work with pathlib.Path objects.

- modified `normalize_file` and `normalize_files`
- added tests
- updated docstrings

Closes: #33 