### PR TITLE
Add support for combining pathspec objects via addition operator

### DIFF
--- a/pathspec/pathspec.py
+++ b/pathspec/pathspec.py
@@ -46,6 +46,27 @@ class PathSpec(object):
 		"""
 		return len(self.patterns)
 
+	def __add__(self, other):
+		"""
+		Combines the :attr:`Pathspec.patterns` patterns from two
+		:class:`PathSpec` instances.
+		"""
+		if isinstance(other, PathSpec):
+			return PathSpec(self.patterns + other.patterns)
+		else:
+			return NotImplemented
+
+	def __iadd__(self, other):
+		"""
+		Adds the :attr:`Pathspec.patterns` patterns from one :class:`PathSpec`
+		instance to this instance.
+		"""
+		if isinstance(other, PathSpec):
+			self.patterns += other.patterns
+			return self
+		else:
+			return NotImplemented
+
 	@classmethod
 	def from_lines(cls, pattern_factory, lines):
 		"""

--- a/pathspec/tests/test_pathspec.py
+++ b/pathspec/tests/test_pathspec.py
@@ -127,3 +127,54 @@ class PathSpecTest(unittest.TestCase):
 			'!*.txt',
 		])
 		self.assertNotEqual(first_spec, second_spec)
+
+	def test_01_addition(self):
+		"""
+		Test pattern addition using + operator
+		"""
+		first_spec = pathspec.PathSpec.from_lines('gitwildmatch', [
+			'test.txt',
+			'test.png'
+		])
+		second_spec = pathspec.PathSpec.from_lines('gitwildmatch', [
+			'test.html',
+			'test.jpg'
+		])
+		combined_spec = first_spec + second_spec
+		results = set(combined_spec.match_files([
+			'test.txt',
+			'test.png',
+			'test.html',
+			'test.jpg'
+		], separators=('\\',)))
+		self.assertEqual(results, {
+			'test.txt',
+			'test.png',
+			'test.html',
+			'test.jpg'
+		})
+
+	def test_02_addition(self):
+		"""
+		Test pattern addition using += operator
+		"""
+		spec = pathspec.PathSpec.from_lines('gitwildmatch', [
+			'test.txt',
+			'test.png'
+		])
+		spec += pathspec.PathSpec.from_lines('gitwildmatch', [
+			'test.html',
+			'test.jpg'
+		])
+		results = set(spec.match_files([
+			'test.txt',
+			'test.png',
+			'test.html',
+			'test.jpg'
+		], separators=('\\',)))
+		self.assertEqual(results, {
+			'test.txt',
+			'test.png',
+			'test.html',
+			'test.jpg'
+		})


### PR DESCRIPTION
This change allows for a set of rules to be expanded using the `+` and `+=` operators.

I wrote these changes for a project of mine which collects patterns from multiple places and needs to combine them into a single `PathSpec` object, but for structural reasons can't practically combine the rules into a single list and pass to `PathSpec.from_lines`.

I also added and verified a couple of test cases for these new operators.

Example usage of + operator:
```python
# Load first spec from a string array
spec1 = pathspec.PathSpec.from_lines('gitwildmatch', [
    'plans_for_world_domination.txt',
    'secret_family_recipe.txt'
])
# Load second spec from a file
fh = open('patterns.txt','r')
spec2 = pathspec.PathSpec.from_lines('gitwildmatch', fh)
# Combine the specs 
combined_spec = spec1 + spec2
```

Example usage of the += operator:
```python
# Load first spec from a string array
spec = pathspec.PathSpec.from_lines('gitwildmatch', [
    'plans_for_world_domination.txt',
    'secret_family_recipe.txt'
])
# Load second spec from a file
fh = open('patterns.txt','r')
spec += pathspec.PathSpec.from_lines('gitwildmatch', fh)
```