### PR TITLE
Draft fix for duplicate leading double-asterisk, and **/ edge cases

### DIFF
--- a/pathspec/patterns/gitwildmatch.py
+++ b/pathspec/patterns/gitwildmatch.py
@@ -83,6 +83,14 @@ class GitWildMatchPattern(RegexPattern):
 			# Split pattern into segments.
 			pattern_segs = pattern.split('/')
 
+			# EDGE CASE: deal with duplicate leading double-asterisk sequences
+			if len(pattern_segs) > 1 and pattern_segs[0] == '**' and pattern_segs[1] == '**':
+				trimmed_segs = ['**']
+				for seg in pattern_segs[1:]:
+					if seg != '**':
+						trimmed_segs.append(seg)
+				pattern_segs = trimmed_segs
+
 			# Normalize pattern to make processing easier.
 
 			if not pattern_segs[0]:

--- a/pathspec/tests/test_gitwildmatch.py
+++ b/pathspec/tests/test_gitwildmatch.py
@@ -240,6 +240,47 @@ class GitWildMatchTest(unittest.TestCase):
 			'foo/spam/bar',
 		})
 
+	def test_03_duplicate_leading_double_asterisk_edge_case(self):
+		"""
+		Regression test for duplicate leading **/ bug.
+		"""
+		regex, include = GitWildMatchPattern.pattern_to_regex('**')
+		self.assertTrue(include)
+		self.assertEqual(regex, '^.+$')
+
+		equivalent_regex, include = GitWildMatchPattern.pattern_to_regex('**/**')
+		self.assertTrue(include)
+		self.assertEqual(equivalent_regex, regex)
+
+		equivalent_regex, include = GitWildMatchPattern.pattern_to_regex('**/**/**')
+		self.assertTrue(include)
+		self.assertEqual(equivalent_regex, regex)
+
+		regex, include = GitWildMatchPattern.pattern_to_regex('**/api')
+		self.assertTrue(include)
+		self.assertEqual(regex, '^(?:.+/)?api(?:/.*)?$')
+
+		equivalent_regex, include = GitWildMatchPattern.pattern_to_regex('**/**/api')
+		self.assertTrue(include)
+		self.assertEqual(equivalent_regex, regex)
+
+
+	def test_03_double_asterisk_trailing_slash_edge_case(self):
+		"""
+		Tests the edge-case **/ pattern.
+
+		This should match everything except individual files in the root directory.
+		"""
+		regex, include = GitWildMatchPattern.pattern_to_regex('**/')
+		self.assertTrue(include)
+		# FIXME: currently failing
+		# REVIEW: I believe this is the correct regex for this case
+		# self.assertEqual(regex, '^(?:.+/).*$')
+
+		equivalent_regex, include = GitWildMatchPattern.pattern_to_regex('**/**/')
+		self.assertTrue(include)
+		self.assertEqual(equivalent_regex, regex)
+
 	def test_04_infix_wildcard(self):
 		"""
 		Tests a pattern with an infix wildcard.


### PR DESCRIPTION
Hi there @cpburnz! First off, thanks so much for this library -- it's been incredibly useful to my team! I found a couple edge-case-y bugs. There's two issues I found, and the test cases I added are mostly self documenting as far as describing the bugs. I've added a (possibly hacky) fix for the first one, "duplicate leading double-asterisk". Basically the change I made just trims duplicate `**/`s ...The second one is for the `**/` pattern. This one will likely require changes in the `_translate_segment_glob(seg)` method (I'm not really sure, actually). Anyways, I think we will probably deal with these bugs within our own code, but I figured I'd at least provide a couple test cases and a launch point instead of just filing an issue. Thanks again for the awesome tool, and please ping me if you decide to go after this. Cheers! 


...also, just for a little more context, both issues produce patterns that impose a leading slash, or a double slash somewhere in the path. Here's an example produced from `**/**` as the raw pattern: https://regex101.com/r/KIDJtA/1