### PR TITLE
Address #44: raise informative exception for invalid git patterns

### DIFF
--- a/pathspec/patterns/gitwildmatch.py
+++ b/pathspec/patterns/gitwildmatch.py
@@ -25,6 +25,14 @@ from ..pattern import RegexPattern
 _BYTES_ENCODING = 'latin1'
 
 
+class GitWildMatchPatternError(ValueError):
+	"""
+	The :class:`GitWildMatchPatternError` indicates an invalid git wild match
+	pattern.
+	"""
+	pass
+
+
 class GitWildMatchPattern(RegexPattern):
 	"""
 	The :class:`GitWildMatchPattern` class represents a compiled Git
@@ -56,6 +64,7 @@ class GitWildMatchPattern(RegexPattern):
 		else:
 			raise TypeError("pattern:{!r} is not a unicode or byte string.".format(pattern))
 
+		original_pattern = pattern
 		pattern = pattern.strip()
 
 		if pattern.startswith('#'):
@@ -136,6 +145,12 @@ class GitWildMatchPattern(RegexPattern):
 				# "dir/{pattern}") should not match "**/dir/{pattern}",
 				# according to `git check-ignore` (v2.4.1).
 				pass
+
+			if not pattern_segs:
+				# After resolving the edge cases, we end up with no
+				# pattern at all. This must be because the pattern is
+				# invalid.
+				raise GitWildMatchPatternError("Invalid git pattern: %r" % (original_pattern,))
 
 			if not pattern_segs[-1] and len(pattern_segs) > 1:
 				# A pattern ending with a slash ('/') will match all

--- a/pathspec/tests/test_gitwildmatch.py
+++ b/pathspec/tests/test_gitwildmatch.py
@@ -10,7 +10,7 @@ import unittest
 
 import pathspec.patterns.gitwildmatch
 import pathspec.util
-from pathspec.patterns.gitwildmatch import GitWildMatchPattern
+from pathspec.patterns.gitwildmatch import GitWildMatchPattern, GitWildMatchPatternError
 
 if sys.version_info[0] >= 3:
 	unichr = chr
@@ -528,3 +528,21 @@ class GitWildMatchTest(unittest.TestCase):
 		escaped = r"file\!with\*weird\#naming_\[1\].t\?t"
 		result = GitWildMatchPattern.escape(fname)
 		self.assertEqual(result, escaped)
+
+	def test_09_single_escape_fail(self):
+		"""
+		Test an escape on a line by itself.
+		"""
+		self._check_invalid_pattern("\\")
+
+	def test_09_single_exclamation_mark_fail(self):
+		"""
+		Test an escape on a line by itself.
+		"""
+		self._check_invalid_pattern("!")
+
+	def _check_invalid_pattern(self, git_ignore_pattern):
+		expected_message_pattern = re.escape(repr(git_ignore_pattern))
+		with self.assertRaisesRegexp(GitWildMatchPatternError, expected_message_pattern):
+			GitWildMatchPattern(git_ignore_pattern)
+


### PR DESCRIPTION
We've addressed the issue that GitWildMatchPattern would raise a cryptic IndexError for invalid git patterns. Instead, we raise an informative exception, `GitWildMatchPatternError` explaining that an invalid pattern was encountered.

This exception is raised for at least the following patterns:
- `!`
- `\`

This PR also partially addresses two issues of `black`: psf/black#2351 psf/black#2359

This PR closes #44 

---

**Attribution:** This PR was a collective effort by @RoelAdriaans @RaviSelker @JohanVergeer @Danjer @jhbuhrman @WPDOrdina @SebastiaanZ during a mob programming session, kindly supported by [Ordina Pythoneers](https://www.ordina.nl/).