### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/pathspec/tests/test_gitwildmatch.py
+++ b/pathspec/tests/test_gitwildmatch.py
@@ -543,6 +543,11 @@ class GitWildMatchTest(unittest.TestCase):
 
 	def _check_invalid_pattern(self, git_ignore_pattern):
 		expected_message_pattern = re.escape(repr(git_ignore_pattern))
-		with self.assertRaisesRegexp(GitWildMatchPatternError, expected_message_pattern):
+		# assertRaisesRegexp was a deprecated alias removed in Python 3.11
+		if hasattr(self, 'assertRaisesRegex'):
+			assertRaisesRegex = self.assertRaisesRegex
+		else:
+			assertRaisesRegex = self.assertRaisesRegexp
+		with assertRaisesRegex(GitWildMatchPatternError, expected_message_pattern):
 			GitWildMatchPattern(git_ignore_pattern)
 


### PR DESCRIPTION
Use `assertRaisesRegex` in Python 3 and when present instead of deprecated alias `assertRaisesRegexp` which is present only in Python 2.

Ref : https://github.com/python/cpython/pull/28268

Fixes below warning : 

```
pytest                 
============================== test session starts ===============================
platform linux -- Python 3.8.0, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
rootdir: /root/python-path-specification
plugins: django-3.9.0, forked-1.1.3, nose2pytest-1.0.8, mock-1.11.1, env-0.6.2, hypothesis-5.20.2, xdist-1.34.0, aiohttp-0.3.0, timeout-1.3.4, cov-2.8.1, pythonpath-0.7.3
collected 54 items                                                               

pathspec/tests/test_gitwildmatch.py ........................s.s.....       [ 59%]
pathspec/tests/test_pathspec.py ..........                                 [ 77%]
pathspec/tests/test_util.py ............                                   [100%]

================================ warnings summary ================================
pathspec/tests/test_gitwildmatch.py::GitWildMatchTest::test_09_single_escape_fail
pathspec/tests/test_gitwildmatch.py::GitWildMatchTest::test_09_single_exclamation_mark_fail
  /root/python-path-specification/pathspec/tests/test_gitwildmatch.py:546: DeprecationWarning: Please use assertRaisesRegex instead.
    with self.assertRaisesRegexp(GitWildMatchPatternError, expected_message_pattern):

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```