### PR TITLE
pyproject.toml: include subpackages in setuptools config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,4 +39,4 @@ requires-python = ">=3.7"
 version = {attr = "pathspec._meta.__version__"}
 
 [tool.setuptools.packages.find]
-include = ["pathspec"]
+include = ["pathspec", "pathspec.*"]


### PR DESCRIPTION
The glob patterns (include/exclude) [must match the entire package name to take effect](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration:~:text=Note%20that%20the%20glob%20patterns%20in%20the%20example%20above%20need%20to%20be%20matched%20by%20the%20entire%20package%20name), so we need to add a wildcard pattern for subpackages. Otherwise, any wheels built won't include subpackages (like `pathspec.patterns`) and things will break >.<

To see the impact of the invalid configuration simply try the following:

- `pip install https://github.com/cpburnz/python-path-specification/archive/master.zip` (pip will build a wheel from source and then install it)
- `python -c "import pathspec"`
- See it blow up with `ImportError: cannot import name 'patterns' from partially initialized module 'pathspec'`

Thank you for maintaining pathspec by the way! :black_heart:  I am one of the maintainers of Black which uses pathspec and it's been great. I noticed this issue since I run [black's test suite daily using the development versions of our dependencies](https://github.com/ichard26/black-deps-ci/runs/7942977472?check_suite_focus=true) (to catch issues early-on, before they get released).